### PR TITLE
V3: Post assistant messages as GitHub PR comments

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,7 @@
   "permissions": ["storage", "activeTab", "declarativeNetRequest"],
   "host_permissions": [
     "https://github.com/*",
+    "https://api.github.com/*",
     "https://*.githubusercontent.com/*",
     "https://*.workers.dev/*"
   ],

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -9,53 +9,115 @@ import type {
   FetchDiffResponse,
   FetchFileRequest,
   FetchFileResponse,
+  PostCommentRequest,
+  PostCommentResponse,
 } from "../shared/types";
 
-chrome.runtime.onMessage.addListener((msg: FetchDiffRequest | FetchFileRequest, _sender, sendResponse) => {
-  if (msg.type === "fetch-diff") {
-    const url = `https://github.com/${msg.owner}/${msg.repo}/pull/${msg.number}.diff`;
+chrome.runtime.onMessage.addListener(
+  (msg: FetchDiffRequest | FetchFileRequest | PostCommentRequest, _sender, sendResponse) => {
+    if (msg.type === "fetch-diff") {
+      const url = `https://github.com/${msg.owner}/${msg.repo}/pull/${msg.number}.diff`;
 
-    fetch(url)
-      .then(async (res) => {
-        if (!res.ok) {
-          sendResponse({ ok: false, error: `HTTP ${res.status}: ${res.statusText}` } satisfies FetchDiffResponse);
-          return;
-        }
-        const diff = await res.text();
-        sendResponse({ ok: true, diff } satisfies FetchDiffResponse);
-      })
-      .catch((err) => {
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Network error",
-        } satisfies FetchDiffResponse);
-      });
+      fetch(url)
+        .then(async (res) => {
+          if (!res.ok) {
+            sendResponse({ ok: false, error: `HTTP ${res.status}: ${res.statusText}` } satisfies FetchDiffResponse);
+            return;
+          }
+          const diff = await res.text();
+          sendResponse({ ok: true, diff } satisfies FetchDiffResponse);
+        })
+        .catch((err) => {
+          sendResponse({
+            ok: false,
+            error: err instanceof Error ? err.message : "Network error",
+          } satisfies FetchDiffResponse);
+        });
 
-    return true;
+      return true;
+    }
+
+    if (msg.type === "fetch-file") {
+      const url = `https://raw.githubusercontent.com/${msg.owner}/${msg.repo}/${msg.branch}/${msg.path}`;
+
+      fetch(url)
+        .then(async (res) => {
+          if (!res.ok) {
+            sendResponse({ ok: false, error: `HTTP ${res.status}: ${res.statusText}` } satisfies FetchFileResponse);
+            return;
+          }
+          const content = await res.text();
+          sendResponse({ ok: true, content } satisfies FetchFileResponse);
+        })
+        .catch((err) => {
+          sendResponse({
+            ok: false,
+            error: err instanceof Error ? err.message : "Network error",
+          } satisfies FetchFileResponse);
+        });
+
+      return true;
+    }
+
+    if (msg.type === "post-comment") {
+      handlePostComment(msg)
+        .then(sendResponse)
+        .catch((err) => {
+          sendResponse({
+            ok: false,
+            error: err instanceof Error ? err.message : "Unknown error",
+          } satisfies PostCommentResponse);
+        });
+      return true;
+    }
+  }
+);
+
+async function handlePostComment(msg: PostCommentRequest): Promise<PostCommentResponse> {
+  const token = await getGithubToken();
+  if (!token) {
+    return {
+      ok: false,
+      error: "No GitHub token configured. Click the PR Sidekick extension icon to add one.",
+    };
   }
 
-  if (msg.type === "fetch-file") {
-    const url = `https://raw.githubusercontent.com/${msg.owner}/${msg.repo}/${msg.branch}/${msg.path}`;
+  const url = `https://api.github.com/repos/${msg.owner}/${msg.repo}/issues/${msg.number}/comments`;
 
-    fetch(url)
-      .then(async (res) => {
-        if (!res.ok) {
-          sendResponse({ ok: false, error: `HTTP ${res.status}: ${res.statusText}` } satisfies FetchFileResponse);
-          return;
-        }
-        const content = await res.text();
-        sendResponse({ ok: true, content } satisfies FetchFileResponse);
-      })
-      .catch((err) => {
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Network error",
-        } satisfies FetchFileResponse);
-      });
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: JSON.stringify({ body: msg.body }),
+  });
 
-    return true;
+  if (!res.ok) {
+    const errorBody = await res.text();
+    let detail = `GitHub API error (${res.status})`;
+    try {
+      const parsed = JSON.parse(errorBody);
+      detail = parsed?.message ?? detail;
+    } catch {
+      // use default
+    }
+    return { ok: false, error: detail };
   }
-});
+
+  const data = await res.json();
+  return { ok: true, url: data.html_url };
+}
+
+async function getGithubToken(): Promise<string | null> {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get([STORAGE_KEYS.GITHUB_TOKEN], (result) => {
+      resolve((result[STORAGE_KEYS.GITHUB_TOKEN] as string) ?? null);
+    });
+  });
+}
 
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name !== "sidekick-chat") return;

--- a/src/content/components/ChatPanel.tsx
+++ b/src/content/components/ChatPanel.tsx
@@ -250,6 +250,9 @@ export function ChatPanel({ onClose, focusedFile, onClearFocus }: ChatPanelProps
           isStreaming={isStreaming}
           focusedFile={focusedFile}
           onPromptSelect={handleSend}
+          prOwner={prContext?.owner}
+          prRepo={prContext?.repo}
+          prNumber={prContext?.number}
         />
       )}
 

--- a/src/content/components/CommentComposer.tsx
+++ b/src/content/components/CommentComposer.tsx
@@ -1,0 +1,141 @@
+import { useState, useRef, useEffect } from "react";
+import type { PostCommentRequest, PostCommentResponse } from "../../shared/types";
+
+interface CommentComposerProps {
+  initialContent: string;
+  owner: string;
+  repo: string;
+  number: number;
+  onClose: () => void;
+}
+
+type PostState = "idle" | "posting" | "posted" | "error";
+
+export function CommentComposer({
+  initialContent,
+  owner,
+  repo,
+  number,
+  onClose,
+}: CommentComposerProps) {
+  const [content, setContent] = useState(initialContent);
+  const [state, setState] = useState<PostState>("idle");
+  const [error, setError] = useState("");
+  const [commentUrl, setCommentUrl] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+    if (textareaRef.current) {
+      textareaRef.current.selectionStart = 0;
+      textareaRef.current.selectionEnd = 0;
+    }
+  }, []);
+
+  const handlePost = async () => {
+    if (!content.trim() || state === "posting") return;
+
+    setState("posting");
+    setError("");
+
+    const msg: PostCommentRequest = {
+      type: "post-comment",
+      owner,
+      repo,
+      number,
+      body: content.trim(),
+    };
+
+    try {
+      const response = await new Promise<PostCommentResponse>((resolve, reject) => {
+        chrome.runtime.sendMessage(msg, (res: PostCommentResponse) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+          resolve(res);
+        });
+      });
+
+      if (response.ok) {
+        setState("posted");
+        setCommentUrl(response.url ?? "");
+        setTimeout(onClose, 2000);
+      } else {
+        setState("error");
+        setError(response.error ?? "Failed to post comment");
+      }
+    } catch (err) {
+      setState("error");
+      setError(err instanceof Error ? err.message : "Failed to post comment");
+    }
+  };
+
+  if (state === "posted") {
+    return (
+      <div className="prs-comment-composer">
+        <div className="prs-comment-composer-success">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+          <span>
+            Comment posted
+            {commentUrl && (
+              <>
+                {" — "}
+                <a
+                  href={commentUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="prs-comment-composer-link"
+                >
+                  view
+                </a>
+              </>
+            )}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="prs-comment-composer">
+      <textarea
+        ref={textareaRef}
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        className="prs-comment-composer-textarea"
+        rows={6}
+        disabled={state === "posting"}
+        placeholder="Edit your comment before posting..."
+      />
+
+      {state === "error" && (
+        <div className="prs-comment-composer-error">{error}</div>
+      )}
+
+      <div className="prs-comment-composer-actions">
+        <span className="prs-comment-composer-hint">
+          Posting to PR #{number}
+        </span>
+        <div className="prs-flex prs-gap-2">
+          <button
+            onClick={onClose}
+            disabled={state === "posting"}
+            className="prs-comment-composer-btn prs-comment-composer-btn-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handlePost}
+            disabled={!content.trim() || state === "posting"}
+            className="prs-comment-composer-btn prs-comment-composer-btn-post"
+          >
+            {state === "posting" ? "Posting..." : "Post Comment"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/content/components/MessageBubble.tsx
+++ b/src/content/components/MessageBubble.tsx
@@ -1,37 +1,102 @@
+import { useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { CommentComposer } from "./CommentComposer";
 import type { ChatMessage } from "../../shared/types";
 
 interface MessageBubbleProps {
   message: ChatMessage;
   isStreaming?: boolean;
+  prOwner?: string;
+  prRepo?: string;
+  prNumber?: number;
 }
 
-export function MessageBubble({ message, isStreaming }: MessageBubbleProps) {
+export function MessageBubble({
+  message,
+  isStreaming,
+  prOwner,
+  prRepo,
+  prNumber,
+}: MessageBubbleProps) {
   const isUser = message.role === "user";
+  const [showComposer, setShowComposer] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const canPost = !isUser && !isStreaming && message.content.length > 0;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(message.content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
 
   return (
-    <div className={`prs-flex ${isUser ? "prs-justify-end" : "prs-justify-start"} prs-mb-3`}>
-      <div
-        className={`prs-max-w-[85%] prs-rounded-xl prs-px-3.5 prs-py-2.5 prs-text-sm prs-leading-relaxed ${
-          isUser
-            ? "prs-bg-purple-600 prs-text-white"
-            : "prs-bg-neutral-100 prs-text-neutral-900"
-        }`}
-      >
-        {isUser ? (
-          <p className="prs-whitespace-pre-wrap">{message.content}</p>
-        ) : (
-          <div className="prs-prose prs-prose-sm prs-max-w-none">
-            <Markdown remarkPlugins={[remarkGfm]}>
-              {message.content}
-            </Markdown>
-            {isStreaming && (
-              <span className="prs-inline-block prs-w-1.5 prs-h-4 prs-bg-purple-500 prs-animate-pulse prs-ml-0.5 prs-align-middle prs-rounded-sm" />
-            )}
+    <div className={`prs-flex prs-flex-col ${isUser ? "prs-items-end" : "prs-items-start"} prs-mb-3`}>
+      <div className="prs-msg-bubble-wrapper">
+        <div
+          className={`prs-max-w-[85%] prs-rounded-xl prs-px-3.5 prs-py-2.5 prs-text-sm prs-leading-relaxed ${
+            isUser
+              ? "prs-bg-purple-600 prs-text-white"
+              : "prs-bg-neutral-100 prs-text-neutral-900"
+          }`}
+        >
+          {isUser ? (
+            <p className="prs-whitespace-pre-wrap">{message.content}</p>
+          ) : (
+            <div className="prs-prose prs-prose-sm prs-max-w-none">
+              <Markdown remarkPlugins={[remarkGfm]}>
+                {message.content}
+              </Markdown>
+              {isStreaming && (
+                <span className="prs-inline-block prs-w-1.5 prs-h-4 prs-bg-purple-500 prs-animate-pulse prs-ml-0.5 prs-align-middle prs-rounded-sm" />
+              )}
+            </div>
+          )}
+        </div>
+
+        {canPost && (
+          <div className="prs-msg-actions">
+            <button
+              onClick={handleCopy}
+              className="prs-msg-action-btn"
+              title={copied ? "Copied!" : "Copy to clipboard"}
+            >
+              {copied ? (
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              ) : (
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                </svg>
+              )}
+            </button>
+            <button
+              onClick={() => setShowComposer(true)}
+              className="prs-msg-action-btn"
+              title="Post as PR comment"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+              </svg>
+            </button>
           </div>
         )}
       </div>
+
+      {showComposer && prOwner && prRepo && prNumber && (
+        <div className="prs-composer-container">
+          <CommentComposer
+            initialContent={message.content}
+            owner={prOwner}
+            repo={prRepo}
+            number={prNumber}
+            onClose={() => setShowComposer(false)}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/content/components/MessageList.tsx
+++ b/src/content/components/MessageList.tsx
@@ -8,9 +8,20 @@ interface MessageListProps {
   isStreaming: boolean;
   focusedFile: string | null;
   onPromptSelect: (prompt: string) => void;
+  prOwner?: string;
+  prRepo?: string;
+  prNumber?: number;
 }
 
-export function MessageList({ messages, isStreaming, focusedFile, onPromptSelect }: MessageListProps) {
+export function MessageList({
+  messages,
+  isStreaming,
+  focusedFile,
+  onPromptSelect,
+  prOwner,
+  prRepo,
+  prNumber,
+}: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -30,6 +41,9 @@ export function MessageList({ messages, isStreaming, focusedFile, onPromptSelect
           key={i}
           message={msg}
           isStreaming={isStreaming && i === messages.length - 1 && msg.role === "assistant"}
+          prOwner={prOwner}
+          prRepo={prRepo}
+          prNumber={prNumber}
         />
       ))}
       <div ref={bottomRef} />

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -304,6 +304,147 @@ function getShadowStyles(): string {
       color: #6d28d9;
     }
 
+    /* Message action bar */
+    .prs-msg-bubble-wrapper {
+      position: relative;
+      max-width: 85%;
+    }
+    .prs-msg-actions {
+      display: none;
+      position: absolute;
+      bottom: -4px;
+      right: 4px;
+      gap: 2px;
+      padding: 2px;
+      border-radius: 8px;
+      background: white;
+      border: 1px solid #e5e5e5;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+      z-index: 1;
+    }
+    .prs-msg-bubble-wrapper:hover .prs-msg-actions {
+      display: flex;
+    }
+    .prs-msg-action-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border-radius: 6px;
+      border: none;
+      background: transparent;
+      color: #737373;
+      cursor: pointer;
+      padding: 0;
+      transition: all 0.15s ease;
+      font-family: inherit;
+    }
+    .prs-msg-action-btn:hover {
+      background: #f5f5f5;
+      color: #7c3aed;
+    }
+
+    /* Comment composer */
+    .prs-composer-container {
+      width: 100%;
+      max-width: 85%;
+      margin-top: 6px;
+    }
+    .prs-comment-composer {
+      border: 1px solid #e5e5e5;
+      border-radius: 10px;
+      background: white;
+      overflow: hidden;
+    }
+    .prs-comment-composer-textarea {
+      display: block;
+      width: 100%;
+      min-height: 100px;
+      max-height: 200px;
+      padding: 10px 12px;
+      border: none;
+      outline: none;
+      resize: vertical;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: #171717;
+      background: #fafafa;
+      box-sizing: border-box;
+    }
+    .prs-comment-composer-textarea:focus {
+      background: #ffffff;
+    }
+    .prs-comment-composer-textarea:disabled {
+      opacity: 0.6;
+    }
+    .prs-comment-composer-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 12px;
+      border-top: 1px solid #f0f0f0;
+      background: white;
+    }
+    .prs-comment-composer-hint {
+      font-size: 0.7rem;
+      color: #a3a3a3;
+    }
+    .prs-comment-composer-btn {
+      display: inline-flex;
+      align-items: center;
+      padding: 5px 14px;
+      border-radius: 6px;
+      border: none;
+      font-size: 0.75rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      font-family: inherit;
+    }
+    .prs-comment-composer-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    .prs-comment-composer-btn-cancel {
+      background: #f5f5f5;
+      color: #525252;
+    }
+    .prs-comment-composer-btn-cancel:hover:not(:disabled) {
+      background: #e5e5e5;
+    }
+    .prs-comment-composer-btn-post {
+      background: #7c3aed;
+      color: white;
+    }
+    .prs-comment-composer-btn-post:hover:not(:disabled) {
+      background: #6d28d9;
+    }
+    .prs-comment-composer-error {
+      padding: 6px 12px;
+      font-size: 0.7rem;
+      color: #dc2626;
+      background: #fef2f2;
+      border-top: 1px solid #fee2e2;
+    }
+    .prs-comment-composer-success {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 10px 12px;
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: #16a34a;
+    }
+    .prs-comment-composer-link {
+      color: #7c3aed;
+      text-decoration: underline;
+    }
+    .prs-comment-composer-link:hover {
+      color: #6d28d9;
+    }
+
     /* Hover */
     .hover\\:prs-bg-purple-700:hover { background-color: #6d28d9; }
     .hover\\:prs-bg-red-600:hover { background-color: #dc2626; }

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -3,6 +3,7 @@ import { STORAGE_KEYS, DEFAULT_PROXY_URL } from "../shared/types";
 
 export function PopupApp() {
   const [apiKey, setApiKey] = useState("");
+  const [githubToken, setGithubToken] = useState("");
   const [proxyUrl, setProxyUrl] = useState(DEFAULT_PROXY_URL);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -10,10 +11,13 @@ export function PopupApp() {
 
   useEffect(() => {
     chrome.storage.sync.get(
-      [STORAGE_KEYS.API_KEY, STORAGE_KEYS.PROXY_URL],
+      [STORAGE_KEYS.API_KEY, STORAGE_KEYS.PROXY_URL, STORAGE_KEYS.GITHUB_TOKEN],
       (result) => {
         if (result[STORAGE_KEYS.API_KEY]) {
           setApiKey(result[STORAGE_KEYS.API_KEY] as string);
+        }
+        if (result[STORAGE_KEYS.GITHUB_TOKEN]) {
+          setGithubToken(result[STORAGE_KEYS.GITHUB_TOKEN] as string);
         }
         if (result[STORAGE_KEYS.PROXY_URL]) {
           setProxyUrl(result[STORAGE_KEYS.PROXY_URL] as string);
@@ -32,6 +36,13 @@ export function PopupApp() {
       [STORAGE_KEYS.API_KEY]: trimmedKey,
     };
 
+    const trimmedGithub = githubToken.trim();
+    if (trimmedGithub) {
+      settings[STORAGE_KEYS.GITHUB_TOKEN] = trimmedGithub;
+    } else {
+      chrome.storage.sync.remove(STORAGE_KEYS.GITHUB_TOKEN);
+    }
+
     const trimmedProxy = proxyUrl.trim();
     if (trimmedProxy && trimmedProxy !== DEFAULT_PROXY_URL) {
       settings[STORAGE_KEYS.PROXY_URL] = trimmedProxy;
@@ -47,9 +58,10 @@ export function PopupApp() {
 
   const handleClear = () => {
     chrome.storage.sync.remove(
-      [STORAGE_KEYS.API_KEY, STORAGE_KEYS.PROXY_URL],
+      [STORAGE_KEYS.API_KEY, STORAGE_KEYS.PROXY_URL, STORAGE_KEYS.GITHUB_TOKEN],
       () => {
         setApiKey("");
+        setGithubToken("");
         setProxyUrl(DEFAULT_PROXY_URL);
         setSaved(false);
       }
@@ -88,6 +100,21 @@ export function PopupApp() {
       <p className="mt-1 text-xs text-neutral-400">
         Your key is stored locally and sent only through the proxy to
         Anthropic's API.
+      </p>
+
+      <label className="block text-sm font-medium text-neutral-700 mb-1.5 mt-4">
+        GitHub Token
+        <span className="text-neutral-400 font-normal"> (optional)</span>
+      </label>
+      <input
+        type="password"
+        value={githubToken}
+        onChange={(e) => setGithubToken(e.target.value)}
+        placeholder="ghp_..."
+        className="w-full px-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+      />
+      <p className="mt-1 text-xs text-neutral-400">
+        Enables posting comments to PRs. Needs <code className="text-xs bg-neutral-100 px-1 rounded">repo</code> scope.
       </p>
 
       <button

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -47,6 +47,20 @@ export interface FetchFileResponse {
   error?: string;
 }
 
+export interface PostCommentRequest {
+  type: "post-comment";
+  owner: string;
+  repo: string;
+  number: number;
+  body: string;
+}
+
+export interface PostCommentResponse {
+  ok: boolean;
+  url?: string;
+  error?: string;
+}
+
 export type StreamEvent =
   | { type: "chunk"; content: string }
   | { type: "done" }
@@ -57,6 +71,7 @@ export const DEFAULT_PROXY_URL = "https://pr-sidekick-proxy.sgunturi.workers.dev
 export const STORAGE_KEYS = {
   API_KEY: "anthropic_api_key",
   PROXY_URL: "proxy_url",
+  GITHUB_TOKEN: "github_token",
   chatHistory: (owner: string, repo: string, number: number) =>
     `chat:${owner}/${repo}#${number}`,
 } as const;


### PR DESCRIPTION
## Summary

- **Post to PR**: Hover over any assistant message to see a small action bar with "Copy" and "Post to PR" buttons. Clicking "Post to PR" opens an inline composer where you can edit the text before posting it as a comment on the PR's conversation timeline.
- **GitHub Token**: New field in the popup settings for a GitHub Personal Access Token (`repo` scope). Stored locally alongside the Anthropic key.
- **Comment Composer**: Full edit flow — textarea pre-filled with the assistant's Markdown, Post/Cancel buttons, posting state, success confirmation with a link to the posted comment, and error handling.

## Files changed

| File | Change |
|---|---|
| `src/shared/types.ts` | Added `GITHUB_TOKEN` to `STORAGE_KEYS`, `PostCommentRequest`/`PostCommentResponse` types |
| `manifest.json` | Added `https://api.github.com/*` to `host_permissions` |
| `src/popup/App.tsx` | Added GitHub token input field |
| `src/background/index.ts` | Added `post-comment` message handler (GitHub REST API) |
| `src/content/components/MessageBubble.tsx` | Added hover action bar with copy + post buttons |
| `src/content/components/CommentComposer.tsx` | **New** — inline editor with post/cancel/success/error states |
| `src/content/components/MessageList.tsx` | Passes PR context down to `MessageBubble` |
| `src/content/components/ChatPanel.tsx` | Passes PR context to `MessageList` |
| `src/content/index.tsx` | Shadow DOM styles for action bar + composer |

## Test plan

- [ ] Add a GitHub PAT in popup settings, verify it saves
- [ ] Chat with a PR, hover over an assistant message → action bar appears
- [ ] Click copy button → content copied to clipboard
- [ ] Click post button → composer opens with message pre-filled
- [ ] Edit the text, click "Post Comment" → comment appears on the PR
- [ ] Verify the "Posted — view" link goes to the right comment
- [ ] Test error state: remove the GitHub token, try posting → see error message