### PR TITLE
refactor: decompose background service worker and fix React patterns

### DIFF
--- a/src/background/githubApi.ts
+++ b/src/background/githubApi.ts
@@ -1,0 +1,520 @@
+import { STORAGE_KEYS } from "../shared/types";
+import type {
+  PostCommentRequest,
+  PostCommentResponse,
+  PostReviewCommentRequest,
+  SubmitReviewRequest,
+  SubmitReviewResponse,
+  FetchEnrichedContextRequest,
+  FetchEnrichedContextResponse,
+  EnrichedPRContext,
+  FetchPRStatsRequest,
+  FetchPRStatsResponse,
+  PRStats,
+  PRCommitSummary,
+  PRReviewVerdict,
+  PRReviewComment,
+  PRCheckRun,
+  PRFileEntry,
+  LinkedIssue,
+  CommitDetail,
+} from "../shared/types";
+
+const GITHUB_API_VERSION = "2022-11-28";
+
+// ── Auth helpers ──
+
+export async function getGithubToken(): Promise<string | null> {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get([STORAGE_KEYS.GITHUB_TOKEN], (result) => {
+      resolve((result[STORAGE_KEYS.GITHUB_TOKEN] as string) ?? null);
+    });
+  });
+}
+
+export async function ghHeaders(): Promise<Record<string, string> | null> {
+  const token = await getGithubToken();
+  if (!token) return null;
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+  };
+}
+
+export async function extractGhError(res: Response): Promise<string> {
+  let detail = `GitHub API error (${res.status})`;
+  try {
+    const parsed = JSON.parse(await res.text());
+    detail = parsed?.message ?? detail;
+  } catch {
+    /* use default */
+  }
+  return detail;
+}
+
+const NO_TOKEN_ERROR = "No GitHub token configured. Click the PRobe extension icon to add one.";
+
+// ── Comment / Review endpoints ──
+
+export async function handlePostComment(msg: PostCommentRequest): Promise<PostCommentResponse> {
+  const headers = await ghHeaders();
+  if (!headers) return { ok: false, error: NO_TOKEN_ERROR };
+
+  const url = `https://api.github.com/repos/${msg.owner}/${msg.repo}/issues/${msg.number}/comments`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ body: msg.body }),
+  });
+
+  if (!res.ok) return { ok: false, error: await extractGhError(res) };
+  const data = await res.json();
+  return { ok: true, url: data.html_url };
+}
+
+export async function handlePostReviewComment(
+  msg: PostReviewCommentRequest,
+): Promise<SubmitReviewResponse> {
+  const headers = await ghHeaders();
+  if (!headers) return { ok: false, error: NO_TOKEN_ERROR };
+
+  const url = `https://api.github.com/repos/${msg.owner}/${msg.repo}/pulls/${msg.number}/reviews`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      event: "COMMENT",
+      comments: [{ path: msg.path, body: msg.body, line: msg.line, side: msg.side }],
+    }),
+  });
+
+  if (!res.ok) return { ok: false, error: await extractGhError(res) };
+  const data = await res.json();
+  return { ok: true, url: data.html_url };
+}
+
+export async function handleSubmitReview(msg: SubmitReviewRequest): Promise<SubmitReviewResponse> {
+  const headers = await ghHeaders();
+  if (!headers) return { ok: false, error: NO_TOKEN_ERROR };
+
+  const url = `https://api.github.com/repos/${msg.owner}/${msg.repo}/pulls/${msg.number}/reviews`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      body: msg.body || undefined,
+      event: msg.event,
+      comments: msg.comments.map((c) => ({
+        path: c.path,
+        body: c.body,
+        line: c.line,
+        side: c.side,
+      })),
+    }),
+  });
+
+  if (!res.ok) return { ok: false, error: await extractGhError(res) };
+  const data = await res.json();
+  return { ok: true, url: data.html_url };
+}
+
+// ── Enriched context assembly ──
+
+interface GHPull {
+  title: string;
+  body: string | null;
+  state: string;
+  draft: boolean;
+  mergeable: boolean | null;
+  mergeable_state: string;
+  user: { login: string } | null;
+  base: { ref: string };
+  head: { ref: string; sha: string };
+  labels: Array<{ name: string }>;
+  milestone: { title: string } | null;
+  assignees: Array<{ login: string }>;
+  requested_reviewers: Array<{ login: string }>;
+}
+
+interface GHCommitListEntry {
+  sha: string;
+  commit: { message: string; author: { name: string; date: string } | null };
+  author: { login: string } | null;
+}
+
+interface GHIssueComment {
+  user: { login: string } | null;
+  body: string;
+  created_at: string;
+}
+
+interface GHReviewComment {
+  user: { login: string } | null;
+  body: string;
+  path: string;
+  line: number | null;
+  created_at: string;
+}
+
+interface GHReview {
+  user: { login: string } | null;
+  state: string;
+  body: string | null;
+}
+
+interface GHFileListEntry {
+  filename: string;
+  status: string;
+  additions: number;
+  deletions: number;
+}
+
+const FILE_CONTENT_BUDGET = 400_000;
+const PER_FILE_CONTENT_CAP = 30_000;
+
+export async function handleFetchEnrichedContext(
+  msg: FetchEnrichedContextRequest,
+  signal: AbortSignal,
+): Promise<FetchEnrichedContextResponse> {
+  const headers = await ghHeaders();
+  if (signal.aborted) return { ok: false, error: "Cancelled" };
+
+  const base = `https://api.github.com/repos/${msg.owner}/${msg.repo}`;
+  const diffUrl = `https://github.com/${msg.owner}/${msg.repo}/pull/${msg.number}.diff`;
+
+  const fetches: Record<string, Promise<Response>> = {
+    diff: fetch(diffUrl, { signal }),
+    pr: headers
+      ? fetch(`${base}/pulls/${msg.number}`, { headers, signal })
+      : Promise.reject("no token"),
+    commits: headers
+      ? fetch(`${base}/pulls/${msg.number}/commits?per_page=100`, { headers, signal })
+      : Promise.reject("no token"),
+    reviews: headers
+      ? fetch(`${base}/pulls/${msg.number}/reviews?per_page=100`, { headers, signal })
+      : Promise.reject("no token"),
+    issueComments: headers
+      ? fetch(`${base}/issues/${msg.number}/comments?per_page=100`, { headers, signal })
+      : Promise.reject("no token"),
+    reviewComments: headers
+      ? fetch(`${base}/pulls/${msg.number}/comments?per_page=100`, { headers, signal })
+      : Promise.reject("no token"),
+    files: headers
+      ? fetch(`${base}/pulls/${msg.number}/files?per_page=100`, { headers, signal })
+      : Promise.reject("no token"),
+  };
+
+  const results = await Promise.allSettled(Object.values(fetches));
+  const keys = Object.keys(fetches);
+  const settled: Record<string, Response | null> = {};
+  for (let i = 0; i < keys.length; i++) {
+    const r = results[i];
+    settled[keys[i]] = r.status === "fulfilled" && r.value.ok ? r.value : null;
+  }
+
+  const diff = settled.diff ? await settled.diff.text() : "";
+  if (!diff) return { ok: false, error: "Failed to fetch PR diff" };
+
+  const pr: GHPull | null = settled.pr ? await settled.pr.json() : null;
+
+  const title = pr?.title ?? `PR #${msg.number}`;
+  const description = pr?.body ?? "";
+  const author = pr?.user?.login ?? "";
+  const baseBranch = pr?.base?.ref ?? "main";
+  const headBranch = pr?.head?.ref ?? "";
+  const headSha = pr?.head?.sha ?? "";
+
+  const rawCommits: GHCommitListEntry[] = settled.commits ? await settled.commits.json() : [];
+  const commits: PRCommitSummary[] = rawCommits.map((c) => ({
+    sha: c.sha.slice(0, 7),
+    message: c.commit.message.split("\n")[0],
+    author: c.author?.login ?? c.commit.author?.name ?? "unknown",
+    date: c.commit.author?.date ?? "",
+  }));
+
+  const rawReviews: GHReview[] = settled.reviews ? await settled.reviews.json() : [];
+  const reviewMap = new Map<string, PRReviewVerdict>();
+  for (const r of rawReviews) {
+    if (!r.user?.login) continue;
+    reviewMap.set(r.user.login, {
+      author: r.user.login,
+      state: r.state,
+      body: r.body ?? "",
+    });
+  }
+  const reviews = Array.from(reviewMap.values());
+
+  const rawIssueComments: GHIssueComment[] = settled.issueComments
+    ? await settled.issueComments.json()
+    : [];
+  const rawReviewComments: GHReviewComment[] = settled.reviewComments
+    ? await settled.reviewComments.json()
+    : [];
+
+  const allComments: PRReviewComment[] = [
+    ...rawIssueComments.map((c) => ({
+      author: c.user?.login ?? "unknown",
+      body: c.body,
+      createdAt: c.created_at,
+    })),
+    ...rawReviewComments.map((c) => ({
+      author: c.user?.login ?? "unknown",
+      body: c.body,
+      path: c.path,
+      line: c.line ?? undefined,
+      createdAt: c.created_at,
+    })),
+  ];
+  allComments.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const recentComments = allComments.slice(0, 5);
+
+  const rawFiles: GHFileListEntry[] = settled.files ? await settled.files.json() : [];
+  const files: PRFileEntry[] = rawFiles.map((f) => ({
+    filename: f.filename,
+    status: f.status,
+    additions: f.additions,
+    deletions: f.deletions,
+  }));
+
+  let checks: PRCheckRun[] = [];
+  if (headers && headSha && !signal.aborted) {
+    try {
+      const checkRes = await fetch(`${base}/commits/${headSha}/check-runs?per_page=100`, {
+        headers,
+        signal,
+      });
+      if (checkRes.ok) {
+        const checkData: {
+          check_runs: Array<{ name: string; status: string; conclusion: string | null }>;
+        } = await checkRes.json();
+        checks = checkData.check_runs.map((cr) => ({
+          name: cr.name,
+          status: cr.status as PRCheckRun["status"],
+          conclusion: cr.conclusion,
+        }));
+      }
+    } catch {
+      /* checks endpoint unavailable */
+    }
+  }
+
+  const linkedIssues: LinkedIssue[] = [];
+  if (headers && description && !signal.aborted) {
+    const issueRefs = new Set<number>();
+    const refRe = /(?:closes|fixes|resolves|part of|related:?)\s+#(\d+)/gi;
+    let refMatch: RegExpExecArray | null;
+    while ((refMatch = refRe.exec(description)) !== null) {
+      issueRefs.add(parseInt(refMatch[1], 10));
+    }
+    const issueResults = await Promise.allSettled(
+      [...issueRefs].map(async (n) => {
+        const res = await fetch(`${base}/issues/${n}`, { headers: headers!, signal });
+        if (!res.ok) return null;
+        const data: { number: number; title: string; body: string | null } = await res.json();
+        return { number: data.number, title: data.title, body: data.body ?? "" };
+      }),
+    );
+    for (const r of issueResults) {
+      if (r.status === "fulfilled" && r.value) linkedIssues.push(r.value);
+    }
+  }
+
+  const partial =
+    !headers || (!pr && commits.length === 0 && reviews.length === 0 && files.length === 0);
+
+  const fetchableFiles = [...files]
+    .filter((f) => f.status !== "removed")
+    .sort((a, b) => b.additions + b.deletions - (a.additions + a.deletions));
+
+  const rawBase = `https://raw.githubusercontent.com/${msg.owner}/${msg.repo}/${headSha}`;
+
+  const fileContents: Record<string, string> = {};
+  let contentBudgetRemaining = FILE_CONTENT_BUDGET;
+
+  if (headSha && !signal.aborted) {
+    const contentResults = await Promise.allSettled(
+      fetchableFiles.map((f) => fetch(`${rawBase}/${f.filename}`, { signal })),
+    );
+
+    for (let i = 0; i < fetchableFiles.length; i++) {
+      if (contentBudgetRemaining <= 0) break;
+      const result = contentResults[i];
+      if (result.status !== "fulfilled" || !result.value.ok) continue;
+      const text = await result.value.text();
+      if (text.slice(0, 1024).includes("\0")) continue;
+      const capped =
+        text.length > PER_FILE_CONTENT_CAP
+          ? text.slice(0, PER_FILE_CONTENT_CAP) + "\n… [truncated]"
+          : text;
+      if (capped.length > contentBudgetRemaining) break;
+      fileContents[fetchableFiles[i].filename] = capped;
+      contentBudgetRemaining -= capped.length;
+    }
+  }
+
+  const context: EnrichedPRContext = {
+    owner: msg.owner,
+    repo: msg.repo,
+    number: msg.number,
+    title,
+    description,
+    diff,
+    headBranch,
+    baseBranch,
+    author,
+    state: pr?.state ?? "open",
+    draft: pr?.draft ?? false,
+    mergeable: pr?.mergeable ?? null,
+    mergeableState: pr?.mergeable_state ?? "unknown",
+    labels: (pr?.labels ?? []).map((l) => l.name),
+    milestone: pr?.milestone?.title ?? "",
+    assignees: (pr?.assignees ?? []).map((a) => a.login),
+    requestedReviewers: (pr?.requested_reviewers ?? []).map((r) => r.login),
+    commits,
+    reviews,
+    recentComments,
+    checks,
+    files,
+    linkedIssues,
+    fileContents: Object.keys(fileContents).length > 0 ? fileContents : undefined,
+    ...(partial ? { partial: true } : {}),
+  };
+
+  return { ok: true, context };
+}
+
+// ── PR Stats ──
+
+interface GHUser {
+  login: string;
+  avatar_url: string;
+}
+
+interface GHPullResponse {
+  additions: number;
+  deletions: number;
+  commits: number;
+  changed_files: number;
+  comments: number;
+  review_comments: number;
+  user: GHUser | null;
+  created_at: string;
+  labels: Array<{ name: string }>;
+}
+
+interface GHFileEntry {
+  filename: string;
+  additions: number;
+  deletions: number;
+}
+
+interface GHCommitEntry {
+  sha: string;
+  author: GHUser | null;
+  commit: {
+    message: string;
+    author: { name: string; date: string } | null;
+  };
+}
+
+interface GHCommitDetailResponse {
+  stats?: { additions: number; deletions: number };
+}
+
+interface GHReviewEntry {
+  user: GHUser | null;
+  state: string;
+}
+
+const MAX_COMMIT_DETAILS = 30;
+
+export async function handleFetchPRStats(
+  msg: FetchPRStatsRequest,
+): Promise<FetchPRStatsResponse> {
+  const headers = await ghHeaders();
+  if (!headers) return { ok: false, error: "No GitHub token configured." };
+
+  const base = `https://api.github.com/repos/${msg.owner}/${msg.repo}/pulls/${msg.number}`;
+
+  const [prRes, filesRes, commitsRes, reviewsRes] = await Promise.all([
+    fetch(base, { headers }),
+    fetch(`${base}/files?per_page=100`, { headers }),
+    fetch(`${base}/commits?per_page=100`, { headers }),
+    fetch(`${base}/reviews?per_page=100`, { headers }),
+  ]);
+
+  if (!prRes.ok) return { ok: false, error: await extractGhError(prRes) };
+
+  const pr: GHPullResponse = await prRes.json();
+  const files: GHFileEntry[] = filesRes.ok ? await filesRes.json() : [];
+  const commits: GHCommitEntry[] = commitsRes.ok ? await commitsRes.json() : [];
+  const reviews: GHReviewEntry[] = reviewsRes.ok ? await reviewsRes.json() : [];
+
+  const authorSet = new Map<string, { login: string; avatarUrl: string }>();
+  for (const c of commits) {
+    const login = c.author?.login ?? c.commit?.author?.name ?? "unknown";
+    const avatarUrl = c.author?.avatar_url ?? "";
+    if (!authorSet.has(login)) authorSet.set(login, { login, avatarUrl });
+  }
+
+  const commitDetailResults = await Promise.all(
+    commits.slice(0, MAX_COMMIT_DETAILS).map(async (c): Promise<GHCommitDetailResponse | null> => {
+      try {
+        const res = await fetch(
+          `https://api.github.com/repos/${msg.owner}/${msg.repo}/commits/${c.sha}`,
+          { headers },
+        );
+        if (!res.ok) return null;
+        return res.json();
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const commitDetails: CommitDetail[] = commits.map((c, i) => {
+    const detail = commitDetailResults[i];
+    return {
+      sha: c.sha ?? "",
+      message: c.commit?.message ?? "",
+      author: c.author?.login ?? c.commit?.author?.name ?? "unknown",
+      avatarUrl: c.author?.avatar_url ?? "",
+      date: c.commit?.author?.date ?? "",
+      additions: detail?.stats?.additions ?? 0,
+      deletions: detail?.stats?.deletions ?? 0,
+    };
+  });
+
+  const reviewerMap = new Map<string, { login: string; avatarUrl: string; state: string }>();
+  for (const r of reviews) {
+    if (!r.user?.login || r.user.login === pr.user?.login) continue;
+    reviewerMap.set(r.user.login, {
+      login: r.user.login,
+      avatarUrl: r.user.avatar_url ?? "",
+      state: r.state,
+    });
+  }
+
+  const stats: PRStats = {
+    additions: pr.additions ?? 0,
+    deletions: pr.deletions ?? 0,
+    commits: pr.commits ?? commits.length,
+    changedFiles: pr.changed_files ?? files.length,
+    comments: (pr.comments ?? 0) + (pr.review_comments ?? 0),
+    author: { login: pr.user?.login ?? "", avatarUrl: pr.user?.avatar_url ?? "" },
+    createdAt: pr.created_at ?? "",
+    labels: (pr.labels ?? []).map((l) => l.name),
+    reviewers: Array.from(reviewerMap.values()),
+    commitAuthors: Array.from(authorSet.values()),
+    files: files.map((f) => ({
+      filename: f.filename,
+      additions: f.additions,
+      deletions: f.deletions,
+    })),
+    commitDetails,
+  };
+
+  return { ok: true, stats };
+}

--- a/src/background/helpers.ts
+++ b/src/background/helpers.ts
@@ -1,0 +1,29 @@
+import type { StreamEvent } from "../shared/types";
+
+/**
+ * Wraps an async message handler so the caller only needs:
+ *   `return dispatchAsync(handlerFn(msg), sendResponse);`
+ * instead of duplicating .then/.catch error‑handling for every message type.
+ */
+export function dispatchAsync<T extends { ok: boolean; error?: string }>(
+  promise: Promise<T>,
+  sendResponse: (response: T) => void,
+): true {
+  promise
+    .then(sendResponse)
+    .catch((err: unknown) => {
+      sendResponse({
+        ok: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      } as T);
+    });
+  return true;
+}
+
+export function sendToPort(port: chrome.runtime.Port, event: StreamEvent) {
+  try {
+    port.postMessage(event);
+  } catch {
+    /* port already disconnected */
+  }
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,22 +1,14 @@
-import { STORAGE_KEYS, DEFAULT_PROXY_URL } from "../shared/types";
+import { dispatchAsync } from "./helpers";
 import {
-  buildSystemPrompt,
-  buildFileSystemPrompt,
-  buildEnrichedSystemPrompt,
-  MODEL_ID,
-} from "../shared/constants";
-import {
-  detectExtensionsFromDiff,
-  matchSkills,
-  type SkillEntry,
-  type ResolvedSkill,
-} from "../shared/skills";
+  handlePostComment,
+  handlePostReviewComment,
+  handleSubmitReview,
+  handleFetchEnrichedContext,
+  handleFetchPRStats,
+} from "./githubApi";
+import { handleChat, handleGeneratePRSummary } from "./llmService";
 import type {
   BackgroundMessage,
-  StreamEvent,
-  ChatMessage,
-  PRContext,
-  EnrichedPRContext,
   FetchDiffRequest,
   FetchDiffResponse,
   FetchFileRequest,
@@ -25,22 +17,10 @@ import type {
   CancelEnrichedContextRequest,
   FetchEnrichedContextResponse,
   PostCommentRequest,
-  PostCommentResponse,
   PostReviewCommentRequest,
   SubmitReviewRequest,
-  SubmitReviewResponse,
   FetchPRStatsRequest,
-  FetchPRStatsResponse,
-  PRStats,
   GeneratePRSummaryRequest,
-  GeneratePRSummaryResponse,
-  PromptSuggestion,
-  PRCommitSummary,
-  PRReviewVerdict,
-  PRReviewComment,
-  PRCheckRun,
-  PRFileEntry,
-  LinkedIssue,
 } from "../shared/types";
 
 type IncomingMessage =
@@ -55,731 +35,102 @@ type IncomingMessage =
   | FetchPRStatsRequest
   | GeneratePRSummaryRequest;
 
+// ── Enriched‑context cancellation registry ──
+
 const enrichedContextControllers = new Map<string, AbortController>();
 
-chrome.runtime.onMessage.addListener((msg: IncomingMessage, _sender, sendResponse) => {
-  if (msg.type === "open-popup") {
+// ── One‑shot message handlers (keyed by msg.type) ──
+// Each entry receives (msg, sendResponse) and returns `true` to keep the
+// message channel open for async responses.  The dispatch table makes
+// adding new message types a one‑line change (Open/Closed principle).
+
+type MessageHandler = (msg: IncomingMessage, sendResponse: (r: unknown) => void) => boolean | void;
+
+function handleFetchDiff(msg: FetchDiffRequest, sendResponse: (r: FetchDiffResponse) => void) {
+  const url = `https://github.com/${msg.owner}/${msg.repo}/pull/${msg.number}.diff`;
+  return dispatchAsync(
+    fetch(url).then(async (res) => {
+      if (!res.ok) return { ok: false as const, error: `HTTP ${res.status}: ${res.statusText}` };
+      return { ok: true as const, diff: await res.text() };
+    }),
+    sendResponse,
+  );
+}
+
+function handleFetchFile(msg: FetchFileRequest, sendResponse: (r: FetchFileResponse) => void) {
+  const url = `https://raw.githubusercontent.com/${msg.owner}/${msg.repo}/${msg.branch}/${msg.path}`;
+  return dispatchAsync(
+    fetch(url).then(async (res) => {
+      if (!res.ok) return { ok: false as const, error: `HTTP ${res.status}: ${res.statusText}` };
+      return { ok: true as const, content: await res.text() };
+    }),
+    sendResponse,
+  );
+}
+
+function handleEnrichedContext(
+  msg: FetchEnrichedContextRequest,
+  sendResponse: (r: FetchEnrichedContextResponse) => void,
+) {
+  const controller = new AbortController();
+  enrichedContextControllers.set(msg.requestId, controller);
+
+  handleFetchEnrichedContext(msg, controller.signal)
+    .then((res) => {
+      enrichedContextControllers.delete(msg.requestId);
+      sendResponse(res);
+    })
+    .catch((err: unknown) => {
+      enrichedContextControllers.delete(msg.requestId);
+      if (controller.signal.aborted) return;
+      sendResponse({
+        ok: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      });
+    });
+  return true;
+}
+
+const messageHandlers: Record<string, MessageHandler> = {
+  "open-popup": (_msg, sendResponse) => {
     chrome.action
       .openPopup()
       .then(() => sendResponse({ ok: true }))
       .catch(() => sendResponse({ ok: false }));
     return true;
-  }
+  },
+  "fetch-diff": (msg, sendResponse) =>
+    handleFetchDiff(msg as FetchDiffRequest, sendResponse as (r: FetchDiffResponse) => void),
+  "fetch-file": (msg, sendResponse) =>
+    handleFetchFile(msg as FetchFileRequest, sendResponse as (r: FetchFileResponse) => void),
+  "fetch-enriched-context": (msg, sendResponse) =>
+    handleEnrichedContext(
+      msg as FetchEnrichedContextRequest,
+      sendResponse as (r: FetchEnrichedContextResponse) => void,
+    ),
+  "cancel-enriched-context": (msg) => {
+    const m = msg as CancelEnrichedContextRequest;
+    enrichedContextControllers.get(m.requestId)?.abort();
+    enrichedContextControllers.delete(m.requestId);
+  },
+  "post-comment": (msg, sendResponse) =>
+    dispatchAsync(handlePostComment(msg as PostCommentRequest), sendResponse),
+  "post-review-comment": (msg, sendResponse) =>
+    dispatchAsync(handlePostReviewComment(msg as PostReviewCommentRequest), sendResponse),
+  "submit-review": (msg, sendResponse) =>
+    dispatchAsync(handleSubmitReview(msg as SubmitReviewRequest), sendResponse),
+  "fetch-pr-stats": (msg, sendResponse) =>
+    dispatchAsync(handleFetchPRStats(msg as FetchPRStatsRequest), sendResponse),
+  "generate-pr-summary": (msg, sendResponse) =>
+    dispatchAsync(handleGeneratePRSummary(msg as GeneratePRSummaryRequest), sendResponse),
+};
 
-  if (msg.type === "fetch-diff") {
-    const url = `https://github.com/${msg.owner}/${msg.repo}/pull/${msg.number}.diff`;
-    fetch(url)
-      .then(async (res) => {
-        if (!res.ok) {
-          sendResponse({
-            ok: false,
-            error: `HTTP ${res.status}: ${res.statusText}`,
-          } satisfies FetchDiffResponse);
-          return;
-        }
-        sendResponse({ ok: true, diff: await res.text() } satisfies FetchDiffResponse);
-      })
-      .catch((err) => {
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Network error",
-        } satisfies FetchDiffResponse);
-      });
-    return true;
-  }
-
-  if (msg.type === "fetch-enriched-context") {
-    const controller = new AbortController();
-    enrichedContextControllers.set(msg.requestId, controller);
-    handleFetchEnrichedContext(msg, controller.signal)
-      .then((res) => {
-        enrichedContextControllers.delete(msg.requestId);
-        sendResponse(res);
-      })
-      .catch((err) => {
-        enrichedContextControllers.delete(msg.requestId);
-        if (controller.signal.aborted) return;
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        } satisfies FetchEnrichedContextResponse);
-      });
-    return true;
-  }
-
-  if (msg.type === "cancel-enriched-context") {
-    enrichedContextControllers.get(msg.requestId)?.abort();
-    enrichedContextControllers.delete(msg.requestId);
-    return false;
-  }
-
-  if (msg.type === "fetch-file") {
-    const url = `https://raw.githubusercontent.com/${msg.owner}/${msg.repo}/${msg.branch}/${msg.path}`;
-    fetch(url)
-      .then(async (res) => {
-        if (!res.ok) {
-          sendResponse({
-            ok: false,
-            error: `HTTP ${res.status}: ${res.statusText}`,
-          } satisfies FetchFileResponse);
-          return;
-        }
-        sendResponse({ ok: true, content: await res.text() } satisfies FetchFileResponse);
-      })
-      .catch((err) => {
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Network error",
-        } satisfies FetchFileResponse);
-      });
-    return true;
-  }
-
-  if (msg.type === "post-comment") {
-    handlePostComment(msg)
-      .then(sendResponse)
-      .catch((err) => {
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        } satisfies PostCommentResponse);
-      });
-    return true;
-  }
-
-  if (msg.type === "post-review-comment") {
-    handlePostReviewComment(msg)
-      .then(sendResponse)
-      .catch((err) => {
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        } satisfies SubmitReviewResponse);
-      });
-    return true;
-  }
-
-  if (msg.type === "submit-review") {
-    handleSubmitReview(msg)
-      .then(sendResponse)
-      .catch((err) => {
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        } satisfies SubmitReviewResponse);
-      });
-    return true;
-  }
-
-  if (msg.type === "fetch-pr-stats") {
-    handleFetchPRStats(msg)
-      .then(sendResponse)
-      .catch((err) => {
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        } satisfies FetchPRStatsResponse);
-      });
-    return true;
-  }
-
-  if (msg.type === "generate-pr-summary") {
-    handleGeneratePRSummary(msg)
-      .then(sendResponse)
-      .catch((err) => {
-        sendResponse({
-          ok: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        } satisfies GeneratePRSummaryResponse);
-      });
-    return true;
-  }
+chrome.runtime.onMessage.addListener((msg: IncomingMessage, _sender, sendResponse) => {
+  const handler = messageHandlers[msg.type];
+  if (handler) return handler(msg, sendResponse);
 });
 
-async function ghHeaders(): Promise<Record<string, string> | null> {
-  const token = await getGithubToken();
-  if (!token) return null;
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "Content-Type": "application/json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-}
-
-async function handlePostComment(msg: PostCommentRequest): Promise<PostCommentResponse> {
-  const headers = await ghHeaders();
-  if (!headers)
-    return {
-      ok: false,
-      error: "No GitHub token configured. Click the PRobe extension icon to add one.",
-    };
-
-  const url = `https://api.github.com/repos/${msg.owner}/${msg.repo}/issues/${msg.number}/comments`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ body: msg.body }),
-  });
-
-  if (!res.ok) return { ok: false, error: await extractGhError(res) };
-  const data = await res.json();
-  return { ok: true, url: data.html_url };
-}
-
-async function handlePostReviewComment(
-  msg: PostReviewCommentRequest,
-): Promise<SubmitReviewResponse> {
-  const headers = await ghHeaders();
-  if (!headers)
-    return {
-      ok: false,
-      error: "No GitHub token configured. Click the PRobe extension icon to add one.",
-    };
-
-  const url = `https://api.github.com/repos/${msg.owner}/${msg.repo}/pulls/${msg.number}/reviews`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      event: "COMMENT",
-      comments: [{ path: msg.path, body: msg.body, line: msg.line, side: msg.side }],
-    }),
-  });
-
-  if (!res.ok) return { ok: false, error: await extractGhError(res) };
-  const data = await res.json();
-  return { ok: true, url: data.html_url };
-}
-
-async function handleSubmitReview(msg: SubmitReviewRequest): Promise<SubmitReviewResponse> {
-  const headers = await ghHeaders();
-  if (!headers)
-    return {
-      ok: false,
-      error: "No GitHub token configured. Click the PRobe extension icon to add one.",
-    };
-
-  const url = `https://api.github.com/repos/${msg.owner}/${msg.repo}/pulls/${msg.number}/reviews`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      body: msg.body || undefined,
-      event: msg.event,
-      comments: msg.comments.map((c) => ({
-        path: c.path,
-        body: c.body,
-        line: c.line,
-        side: c.side,
-      })),
-    }),
-  });
-
-  if (!res.ok) return { ok: false, error: await extractGhError(res) };
-  const data = await res.json();
-  return { ok: true, url: data.html_url };
-}
-
-// ── Enriched context assembly ──
-
-async function handleFetchEnrichedContext(
-  msg: FetchEnrichedContextRequest,
-  signal: AbortSignal,
-): Promise<FetchEnrichedContextResponse> {
-  const headers = await ghHeaders();
-  if (signal.aborted) return { ok: false, error: "Cancelled" };
-
-  const base = `https://api.github.com/repos/${msg.owner}/${msg.repo}`;
-  const diffUrl = `https://github.com/${msg.owner}/${msg.repo}/pull/${msg.number}.diff`;
-
-  const fetches: Record<string, Promise<Response>> = {
-    diff: fetch(diffUrl, { signal }),
-    pr: headers
-      ? fetch(`${base}/pulls/${msg.number}`, { headers, signal })
-      : Promise.reject("no token"),
-    commits: headers
-      ? fetch(`${base}/pulls/${msg.number}/commits?per_page=100`, { headers, signal })
-      : Promise.reject("no token"),
-    reviews: headers
-      ? fetch(`${base}/pulls/${msg.number}/reviews?per_page=100`, { headers, signal })
-      : Promise.reject("no token"),
-    issueComments: headers
-      ? fetch(`${base}/issues/${msg.number}/comments?per_page=100`, { headers, signal })
-      : Promise.reject("no token"),
-    reviewComments: headers
-      ? fetch(`${base}/pulls/${msg.number}/comments?per_page=100`, { headers, signal })
-      : Promise.reject("no token"),
-    files: headers
-      ? fetch(`${base}/pulls/${msg.number}/files?per_page=100`, { headers, signal })
-      : Promise.reject("no token"),
-  };
-
-  const results = await Promise.allSettled(Object.values(fetches));
-  const keys = Object.keys(fetches);
-  const settled: Record<string, Response | null> = {};
-  for (let i = 0; i < keys.length; i++) {
-    const r = results[i];
-    settled[keys[i]] = r.status === "fulfilled" && r.value.ok ? r.value : null;
-  }
-
-  const diff = settled.diff ? await settled.diff.text() : "";
-  if (!diff) {
-    return { ok: false, error: "Failed to fetch PR diff" };
-  }
-
-  interface GHPull {
-    title: string;
-    body: string | null;
-    state: string;
-    draft: boolean;
-    mergeable: boolean | null;
-    mergeable_state: string;
-    user: { login: string } | null;
-    base: { ref: string };
-    head: { ref: string; sha: string };
-    labels: Array<{ name: string }>;
-    milestone: { title: string } | null;
-    assignees: Array<{ login: string }>;
-    requested_reviewers: Array<{ login: string }>;
-  }
-
-  const pr: GHPull | null = settled.pr ? await settled.pr.json() : null;
-
-  const title = pr?.title ?? `PR #${msg.number}`;
-  const description = pr?.body ?? "";
-  const author = pr?.user?.login ?? "";
-  const baseBranch = pr?.base?.ref ?? "main";
-  const headBranch = pr?.head?.ref ?? "";
-  const headSha = pr?.head?.sha ?? "";
-
-  // Commits
-  interface GHCommitListEntry {
-    sha: string;
-    commit: { message: string; author: { name: string; date: string } | null };
-    author: { login: string } | null;
-  }
-  const rawCommits: GHCommitListEntry[] = settled.commits ? await settled.commits.json() : [];
-  const commits: PRCommitSummary[] = rawCommits.map((c) => ({
-    sha: c.sha.slice(0, 7),
-    message: c.commit.message.split("\n")[0],
-    author: c.author?.login ?? c.commit.author?.name ?? "unknown",
-    date: c.commit.author?.date ?? "",
-  }));
-
-  // Reviews (verdicts)
-  interface GHReview {
-    user: { login: string } | null;
-    state: string;
-    body: string | null;
-  }
-  const rawReviews: GHReview[] = settled.reviews ? await settled.reviews.json() : [];
-  const reviewMap = new Map<string, PRReviewVerdict>();
-  for (const r of rawReviews) {
-    if (!r.user?.login) continue;
-    reviewMap.set(r.user.login, {
-      author: r.user.login,
-      state: r.state,
-      body: r.body ?? "",
-    });
-  }
-  const reviews = Array.from(reviewMap.values());
-
-  // Recent comments: merge PR-level and inline, take latest 5
-  interface GHIssueComment {
-    user: { login: string } | null;
-    body: string;
-    created_at: string;
-  }
-  interface GHReviewComment {
-    user: { login: string } | null;
-    body: string;
-    path: string;
-    line: number | null;
-    created_at: string;
-  }
-  const rawIssueComments: GHIssueComment[] = settled.issueComments
-    ? await settled.issueComments.json()
-    : [];
-  const rawReviewComments: GHReviewComment[] = settled.reviewComments
-    ? await settled.reviewComments.json()
-    : [];
-
-  const allComments: PRReviewComment[] = [
-    ...rawIssueComments.map((c) => ({
-      author: c.user?.login ?? "unknown",
-      body: c.body,
-      createdAt: c.created_at,
-    })),
-    ...rawReviewComments.map((c) => ({
-      author: c.user?.login ?? "unknown",
-      body: c.body,
-      path: c.path,
-      line: c.line ?? undefined,
-      createdAt: c.created_at,
-    })),
-  ];
-  allComments.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-  const recentComments = allComments.slice(0, 5);
-
-  // Files
-  interface GHFileListEntry {
-    filename: string;
-    status: string;
-    additions: number;
-    deletions: number;
-  }
-  const rawFiles: GHFileListEntry[] = settled.files ? await settled.files.json() : [];
-  const files: PRFileEntry[] = rawFiles.map((f) => ({
-    filename: f.filename,
-    status: f.status,
-    additions: f.additions,
-    deletions: f.deletions,
-  }));
-
-  // Checks (CI) for head commit
-  let checks: PRCheckRun[] = [];
-  if (headers && headSha && !signal.aborted) {
-    try {
-      const checkRes = await fetch(`${base}/commits/${headSha}/check-runs?per_page=100`, {
-        headers,
-        signal,
-      });
-      if (checkRes.ok) {
-        const checkData: {
-          check_runs: Array<{ name: string; status: string; conclusion: string | null }>;
-        } = await checkRes.json();
-        checks = checkData.check_runs.map((cr) => ({
-          name: cr.name,
-          status: cr.status as PRCheckRun["status"],
-          conclusion: cr.conclusion,
-        }));
-      }
-    } catch {
-      /* checks unavailable */
-    }
-  }
-
-  // Linked issues: parse PR body for #N references
-  const linkedIssues: LinkedIssue[] = [];
-  if (headers && description && !signal.aborted) {
-    const issueRefs = new Set<number>();
-    const refRe = /(?:closes|fixes|resolves|part of|related:?)\s+#(\d+)/gi;
-    let refMatch: RegExpExecArray | null;
-    while ((refMatch = refRe.exec(description)) !== null) {
-      issueRefs.add(parseInt(refMatch[1], 10));
-    }
-    const issueResults = await Promise.allSettled(
-      [...issueRefs].map(async (n) => {
-        const res = await fetch(`${base}/issues/${n}`, { headers: headers!, signal });
-        if (!res.ok) return null;
-        const data: { number: number; title: string; body: string | null } = await res.json();
-        return { number: data.number, title: data.title, body: data.body ?? "" };
-      }),
-    );
-    for (const r of issueResults) {
-      if (r.status === "fulfilled" && r.value) linkedIssues.push(r.value);
-    }
-  }
-
-  const partial =
-    !headers || (!pr && commits.length === 0 && reviews.length === 0 && files.length === 0);
-
-  // Full head-branch file contents — fetch for all non-deleted files,
-  // subject to a 400K char total budget. Files sorted by change volume so
-  // the highest-impact files get full content first.
-  const FILE_CONTENT_BUDGET = 400_000;
-  const PER_FILE_CONTENT_CAP = 30_000;
-
-  const fetchableFiles = [...files]
-    .filter((f) => f.status !== "removed")
-    .sort((a, b) => b.additions + b.deletions - (a.additions + a.deletions));
-
-  const rawBase = `https://raw.githubusercontent.com/${msg.owner}/${msg.repo}/${headSha}`;
-
-  const fileContents: Record<string, string> = {};
-  let contentBudgetRemaining = FILE_CONTENT_BUDGET;
-
-  if (headSha && !signal.aborted) {
-    const contentResults = await Promise.allSettled(
-      fetchableFiles.map((f) => fetch(`${rawBase}/${f.filename}`, { signal })),
-    );
-
-    for (let i = 0; i < fetchableFiles.length; i++) {
-      if (contentBudgetRemaining <= 0) break;
-      const result = contentResults[i];
-      if (result.status !== "fulfilled" || !result.value.ok) continue;
-      const text = await result.value.text();
-      // Skip likely binary files (null bytes in first 1K chars)
-      if (text.slice(0, 1024).includes("\0")) continue;
-      const capped =
-        text.length > PER_FILE_CONTENT_CAP
-          ? text.slice(0, PER_FILE_CONTENT_CAP) + "\n… [truncated]"
-          : text;
-      if (capped.length > contentBudgetRemaining) break;
-      fileContents[fetchableFiles[i].filename] = capped;
-      contentBudgetRemaining -= capped.length;
-    }
-  }
-
-  const context: EnrichedPRContext = {
-    owner: msg.owner,
-    repo: msg.repo,
-    number: msg.number,
-    title,
-    description,
-    diff,
-    headBranch,
-    baseBranch,
-    author,
-    state: pr?.state ?? "open",
-    draft: pr?.draft ?? false,
-    mergeable: pr?.mergeable ?? null,
-    mergeableState: pr?.mergeable_state ?? "unknown",
-    labels: (pr?.labels ?? []).map((l) => l.name),
-    milestone: pr?.milestone?.title ?? "",
-    assignees: (pr?.assignees ?? []).map((a) => a.login),
-    requestedReviewers: (pr?.requested_reviewers ?? []).map((r) => r.login),
-    commits,
-    reviews,
-    recentComments,
-    checks,
-    files,
-    linkedIssues,
-    fileContents: Object.keys(fileContents).length > 0 ? fileContents : undefined,
-    ...(partial ? { partial: true } : {}),
-  };
-
-  return { ok: true, context };
-}
-
-async function extractGhError(res: Response): Promise<string> {
-  let detail = `GitHub API error (${res.status})`;
-  try {
-    const parsed = JSON.parse(await res.text());
-    detail = parsed?.message ?? detail;
-  } catch {
-    /* use default */
-  }
-  return detail;
-}
-
-async function getGithubToken(): Promise<string | null> {
-  return new Promise((resolve) => {
-    chrome.storage.sync.get([STORAGE_KEYS.GITHUB_TOKEN], (result) => {
-      resolve((result[STORAGE_KEYS.GITHUB_TOKEN] as string) ?? null);
-    });
-  });
-}
-
-interface GHUser {
-  login: string;
-  avatar_url: string;
-}
-
-interface GHPullResponse {
-  additions: number;
-  deletions: number;
-  commits: number;
-  changed_files: number;
-  comments: number;
-  review_comments: number;
-  user: GHUser | null;
-  created_at: string;
-  labels: Array<{ name: string }>;
-}
-
-interface GHFileEntry {
-  filename: string;
-  additions: number;
-  deletions: number;
-}
-
-interface GHCommitEntry {
-  sha: string;
-  author: GHUser | null;
-  commit: {
-    message: string;
-    author: { name: string; date: string } | null;
-  };
-}
-
-interface GHCommitDetailResponse {
-  stats?: { additions: number; deletions: number };
-}
-
-interface GHReviewEntry {
-  user: GHUser | null;
-  state: string;
-}
-
-async function handleFetchPRStats(msg: FetchPRStatsRequest): Promise<FetchPRStatsResponse> {
-  const headers = await ghHeaders();
-  if (!headers) return { ok: false, error: "No GitHub token configured." };
-
-  const base = `https://api.github.com/repos/${msg.owner}/${msg.repo}/pulls/${msg.number}`;
-
-  const [prRes, filesRes, commitsRes, reviewsRes] = await Promise.all([
-    fetch(base, { headers }),
-    fetch(`${base}/files?per_page=100`, { headers }),
-    fetch(`${base}/commits?per_page=100`, { headers }),
-    fetch(`${base}/reviews?per_page=100`, { headers }),
-  ]);
-
-  if (!prRes.ok) return { ok: false, error: await extractGhError(prRes) };
-
-  const pr: GHPullResponse = await prRes.json();
-  const files: GHFileEntry[] = filesRes.ok ? await filesRes.json() : [];
-  const commits: GHCommitEntry[] = commitsRes.ok ? await commitsRes.json() : [];
-  const reviews: GHReviewEntry[] = reviewsRes.ok ? await reviewsRes.json() : [];
-
-  const authorSet = new Map<string, { login: string; avatarUrl: string }>();
-  for (const c of commits) {
-    const login = c.author?.login ?? c.commit?.author?.name ?? "unknown";
-    const avatarUrl = c.author?.avatar_url ?? "";
-    if (!authorSet.has(login)) authorSet.set(login, { login, avatarUrl });
-  }
-
-  const commitDetailResults = await Promise.all(
-    commits.slice(0, 30).map(async (c): Promise<GHCommitDetailResponse | null> => {
-      try {
-        const res = await fetch(
-          `https://api.github.com/repos/${msg.owner}/${msg.repo}/commits/${c.sha}`,
-          { headers },
-        );
-        if (!res.ok) return null;
-        return res.json();
-      } catch {
-        return null;
-      }
-    }),
-  );
-
-  const commitDetails: import("../shared/types").CommitDetail[] = commits.map((c, i) => {
-    const detail = commitDetailResults[i];
-    return {
-      sha: c.sha ?? "",
-      message: c.commit?.message ?? "",
-      author: c.author?.login ?? c.commit?.author?.name ?? "unknown",
-      avatarUrl: c.author?.avatar_url ?? "",
-      date: c.commit?.author?.date ?? "",
-      additions: detail?.stats?.additions ?? 0,
-      deletions: detail?.stats?.deletions ?? 0,
-    };
-  });
-
-  const reviewerMap = new Map<string, { login: string; avatarUrl: string; state: string }>();
-  for (const r of reviews) {
-    if (!r.user?.login || r.user.login === pr.user?.login) continue;
-    reviewerMap.set(r.user.login, {
-      login: r.user.login,
-      avatarUrl: r.user.avatar_url ?? "",
-      state: r.state,
-    });
-  }
-
-  const stats: PRStats = {
-    additions: pr.additions ?? 0,
-    deletions: pr.deletions ?? 0,
-    commits: pr.commits ?? commits.length,
-    changedFiles: pr.changed_files ?? files.length,
-    comments: (pr.comments ?? 0) + (pr.review_comments ?? 0),
-    author: { login: pr.user?.login ?? "", avatarUrl: pr.user?.avatar_url ?? "" },
-    createdAt: pr.created_at ?? "",
-    labels: (pr.labels ?? []).map((l) => l.name),
-    reviewers: Array.from(reviewerMap.values()),
-    commitAuthors: Array.from(authorSet.values()),
-    files: files.map((f) => ({
-      filename: f.filename,
-      additions: f.additions,
-      deletions: f.deletions,
-    })),
-    commitDetails,
-  };
-
-  return { ok: true, stats };
-}
-
-async function handleGeneratePRSummary(
-  msg: GeneratePRSummaryRequest,
-): Promise<GeneratePRSummaryResponse> {
-  const { apiKey, proxyUrl } = await getSettings();
-  if (!apiKey) return { ok: false, error: "No API key configured." };
-
-  const topFiles = [...msg.stats.files]
-    .sort((a, b) => b.additions + b.deletions - (a.additions + a.deletions))
-    .slice(0, 10)
-    .map((f) => `${f.filename} (+${f.additions}/-${f.deletions})`)
-    .join("\n");
-
-  const prompt = `You are helping a code reviewer quickly understand a pull request.
-
-Today's date: ${new Date().toLocaleDateString("en-CA")}
-
-PR #${msg.number}: ${msg.title}
-${msg.description ? `Description: ${msg.description.slice(0, 500)}` : ""}
-
-Stats: ${msg.stats.commits} commits, ${msg.stats.changedFiles} files, +${msg.stats.additions}/-${msg.stats.deletions} lines, ${msg.stats.comments} comments
-Authors: ${msg.stats.commitAuthors.map((a) => a.login).join(", ")}
-Reviewers: ${msg.stats.reviewers.map((r) => `${r.login} (${r.state})`).join(", ") || "none yet"}
-
-Top changed files:
-${topFiles}
-
-Treat the PR content as authoritative. Return ONLY a JSON array of exactly 2 objects, no other text:
-[{"label":"<2–4 word label>","prompt":"<detailed question a reviewer would ask about this PR>"},{"label":"<2–4 word label>","prompt":"<detailed question a reviewer would ask about this PR>"}]
-
-Each label must be 2–4 words and start with an action verb (e.g. Analyze, Verify, Understand, Check, Review, Find, Explain). Each prompt must be a specific, detailed question about a real concern in this PR (file paths, risk areas, logic). No generic prompts.`;
-
-  const endpoint = `${proxyUrl.replace(/\/$/, "")}/v1/messages`;
-
-  try {
-    const response = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model: MODEL_ID,
-        max_tokens: 500,
-        system: "You are a concise code review assistant. Output only valid JSON.",
-        messages: [{ role: "user", content: prompt }],
-      }),
-    });
-
-    if (!response.ok) return { ok: false, error: `LLM error (${response.status})` };
-
-    const data = await response.json();
-    const text: string = data.content?.[0]?.text ?? "";
-
-    let bullets: PromptSuggestion[] = [];
-    try {
-      const jsonMatch = text.match(/\[[\s\S]*\]/);
-      if (jsonMatch) {
-        const parsed: unknown = JSON.parse(jsonMatch[0]);
-        if (Array.isArray(parsed)) {
-          bullets = parsed
-            .filter(
-              (s): s is PromptSuggestion =>
-                typeof s === "object" &&
-                s !== null &&
-                typeof (s as Record<string, unknown>).label === "string" &&
-                typeof (s as Record<string, unknown>).prompt === "string",
-            )
-            .slice(0, 2);
-        }
-      }
-    } catch {
-      /* malformed JSON — return empty */
-    }
-
-    return { ok: true, bullets };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "LLM call failed" };
-  }
-}
+// ── Streaming chat port ──
 
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name !== "probe-chat") return;
@@ -807,219 +158,3 @@ chrome.runtime.onConnect.addListener((port) => {
     abortController?.abort();
   });
 });
-
-async function getSettings(): Promise<{ apiKey: string | null; proxyUrl: string }> {
-  return new Promise((resolve) => {
-    chrome.storage.sync.get([STORAGE_KEYS.API_KEY, STORAGE_KEYS.PROXY_URL], (result) => {
-      const raw = (result[STORAGE_KEYS.PROXY_URL] as string) || "";
-      resolve({
-        apiKey: (result[STORAGE_KEYS.API_KEY] as string) ?? null,
-        proxyUrl: raw.startsWith("https://") ? raw : DEFAULT_PROXY_URL,
-      });
-    });
-  });
-}
-
-function send(port: chrome.runtime.Port, event: StreamEvent) {
-  try {
-    port.postMessage(event);
-  } catch {
-    /* Port disconnected */
-  }
-}
-
-// ── Skill resolution ──
-
-const SKILL_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 h
-
-interface CachedSkill {
-  content: string;
-  fetchedAt: number;
-}
-
-function stripYamlFrontmatter(md: string): string {
-  return md.replace(/^---[\s\S]*?---\s*/, "");
-}
-
-async function fetchSkillContent(skill: SkillEntry): Promise<string | null> {
-  const cacheKey = `skill:${skill.id}`;
-
-  const cached = await new Promise<CachedSkill | null>((resolve) => {
-    chrome.storage.local.get([cacheKey], (result) => {
-      const data = result[cacheKey] as CachedSkill | undefined;
-      if (data && Date.now() - data.fetchedAt < SKILL_CACHE_TTL) {
-        resolve(data);
-      } else {
-        resolve(null);
-      }
-    });
-  });
-
-  if (cached) return cached.content;
-
-  try {
-    const res = await fetch(skill.rawUrl);
-    if (!res.ok) return null;
-
-    let content = stripYamlFrontmatter(await res.text());
-
-    if (content.length > skill.maxContentLength) {
-      const cutoff = content.lastIndexOf("\n", skill.maxContentLength);
-      content =
-        content.slice(0, cutoff > 0 ? cutoff : skill.maxContentLength) +
-        "\n\n… [truncated for brevity]";
-    }
-
-    chrome.storage.local.set({
-      [cacheKey]: { content, fetchedAt: Date.now() } satisfies CachedSkill,
-    });
-
-    return content;
-  } catch {
-    return null;
-  }
-}
-
-async function resolveSkillsForDiff(diff: string): Promise<ResolvedSkill[]> {
-  const extensions = detectExtensionsFromDiff(diff);
-  const matched = matchSkills(extensions);
-  if (matched.length === 0) return [];
-
-  const results = await Promise.all(
-    matched.map(async (skill) => {
-      const content = await fetchSkillContent(skill);
-      return content
-        ? { name: skill.name, content, sourceUrl: skill.sourceUrl, description: skill.description }
-        : null;
-    }),
-  );
-
-  return results.filter((r): r is ResolvedSkill => r !== null);
-}
-
-// ── Chat handler ──
-
-async function handleChat(
-  port: chrome.runtime.Port,
-  messages: ChatMessage[],
-  context: PRContext,
-  signal: AbortSignal,
-  enrichedContext?: EnrichedPRContext,
-) {
-  const { apiKey, proxyUrl } = await getSettings();
-  if (!apiKey) {
-    send(port, {
-      type: "error",
-      message:
-        "No API key configured. Click the PRobe extension icon to add your Anthropic API key.",
-    });
-    return;
-  }
-
-  const skills = await resolveSkillsForDiff(context.diff);
-
-  if (skills.length > 0) {
-    send(port, {
-      type: "skills",
-      skills: skills.map((s) => ({
-        name: s.name,
-        sourceUrl: s.sourceUrl,
-        description: s.description,
-      })),
-    });
-  }
-
-  let systemPrompt: string;
-  if (context.focusedFile) {
-    systemPrompt = buildFileSystemPrompt(
-      context,
-      context.focusedFile,
-      context.diff,
-      context.focusedFileContent,
-      context.focusedLineRange,
-      skills,
-    );
-  } else if (enrichedContext) {
-    systemPrompt = buildEnrichedSystemPrompt(enrichedContext, skills);
-  } else {
-    systemPrompt = buildSystemPrompt(context, skills);
-  }
-
-  send(port, { type: "system-prompt", content: systemPrompt });
-
-  const anthropicMessages = messages.map((m) => ({
-    role: m.role as "user" | "assistant",
-    content: m.content,
-  }));
-
-  const endpoint = `${proxyUrl.replace(/\/$/, "")}/v1/messages`;
-
-  try {
-    const response = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model: MODEL_ID,
-        max_tokens: 4096,
-        stream: true,
-        system: systemPrompt,
-        messages: anthropicMessages,
-      }),
-      signal,
-    });
-
-    if (!response.ok) {
-      const errorBody = await response.text();
-      let errorMessage = `Anthropic API error (${response.status})`;
-      try {
-        const parsed = JSON.parse(errorBody);
-        errorMessage = parsed?.error?.message ?? errorMessage;
-      } catch {
-        /* use default */
-      }
-      send(port, { type: "error", message: errorMessage });
-      return;
-    }
-
-    const reader = response.body?.getReader();
-    if (!reader) {
-      send(port, { type: "error", message: "No response body" });
-      return;
-    }
-
-    const decoder = new TextDecoder();
-    let buffer = "";
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-
-      for (const line of lines) {
-        if (!line.startsWith("data: ")) continue;
-        const data = line.slice(6).trim();
-        if (data === "[DONE]") continue;
-        try {
-          const event = JSON.parse(data);
-          if (event.type === "content_block_delta" && event.delta?.type === "text_delta") {
-            send(port, { type: "chunk", content: event.delta.text });
-          }
-        } catch {
-          /* skip malformed SSE */
-        }
-      }
-    }
-
-    send(port, { type: "done" });
-  } catch (err: unknown) {
-    if (signal.aborted) return;
-    send(port, { type: "error", message: err instanceof Error ? err.message : "Unknown error" });
-  }
-}

--- a/src/background/llmService.ts
+++ b/src/background/llmService.ts
@@ -1,0 +1,230 @@
+import { STORAGE_KEYS, DEFAULT_PROXY_URL } from "../shared/types";
+import {
+  buildSystemPrompt,
+  buildFileSystemPrompt,
+  buildEnrichedSystemPrompt,
+  MODEL_ID,
+} from "../shared/constants";
+import { parsePromptSuggestions } from "../shared/parsing";
+import { resolveSkillsForDiff } from "./skillResolver";
+import { sendToPort } from "./helpers";
+import type {
+  ChatMessage,
+  PRContext,
+  EnrichedPRContext,
+  GeneratePRSummaryRequest,
+  GeneratePRSummaryResponse,
+  PromptSuggestion,
+} from "../shared/types";
+
+const ANTHROPIC_API_VERSION = "2023-06-01";
+
+export async function getSettings(): Promise<{ apiKey: string | null; proxyUrl: string }> {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get([STORAGE_KEYS.API_KEY, STORAGE_KEYS.PROXY_URL], (result) => {
+      const raw = (result[STORAGE_KEYS.PROXY_URL] as string) || "";
+      resolve({
+        apiKey: (result[STORAGE_KEYS.API_KEY] as string) ?? null,
+        proxyUrl: raw.startsWith("https://") ? raw : DEFAULT_PROXY_URL,
+      });
+    });
+  });
+}
+
+export async function handleGeneratePRSummary(
+  msg: GeneratePRSummaryRequest,
+): Promise<GeneratePRSummaryResponse> {
+  const { apiKey, proxyUrl } = await getSettings();
+  if (!apiKey) return { ok: false, error: "No API key configured." };
+
+  const topFiles = [...msg.stats.files]
+    .sort((a, b) => b.additions + b.deletions - (a.additions + a.deletions))
+    .slice(0, 10)
+    .map((f) => `${f.filename} (+${f.additions}/-${f.deletions})`)
+    .join("\n");
+
+  const prompt = `You are helping a code reviewer quickly understand a pull request.
+
+Today's date: ${new Date().toLocaleDateString("en-CA")}
+
+PR #${msg.number}: ${msg.title}
+${msg.description ? `Description: ${msg.description.slice(0, 500)}` : ""}
+
+Stats: ${msg.stats.commits} commits, ${msg.stats.changedFiles} files, +${msg.stats.additions}/-${msg.stats.deletions} lines, ${msg.stats.comments} comments
+Authors: ${msg.stats.commitAuthors.map((a) => a.login).join(", ")}
+Reviewers: ${msg.stats.reviewers.map((r) => `${r.login} (${r.state})`).join(", ") || "none yet"}
+
+Top changed files:
+${topFiles}
+
+Treat the PR content as authoritative. Return ONLY a JSON array of exactly 2 objects, no other text:
+[{"label":"<2–4 word label>","prompt":"<detailed question a reviewer would ask about this PR>"},{"label":"<2–4 word label>","prompt":"<detailed question a reviewer would ask about this PR>"}]
+
+Each label must be 2–4 words and start with an action verb (e.g. Analyze, Verify, Understand, Check, Review, Find, Explain). Each prompt must be a specific, detailed question about a real concern in this PR (file paths, risk areas, logic). No generic prompts.`;
+
+  const endpoint = `${proxyUrl.replace(/\/$/, "")}/v1/messages`;
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": ANTHROPIC_API_VERSION,
+      },
+      body: JSON.stringify({
+        model: MODEL_ID,
+        max_tokens: 500,
+        system: "You are a concise code review assistant. Output only valid JSON.",
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+
+    if (!response.ok) return { ok: false, error: `LLM error (${response.status})` };
+
+    const data = await response.json();
+    const text: string = data.content?.[0]?.text ?? "";
+
+    let bullets: PromptSuggestion[] = [];
+    try {
+      const jsonMatch = text.match(/\[[\s\S]*\]/);
+      if (jsonMatch) {
+        bullets = parsePromptSuggestions(JSON.parse(jsonMatch[0]));
+      }
+    } catch {
+      /* malformed JSON — return empty */
+    }
+
+    return { ok: true, bullets };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "LLM call failed" };
+  }
+}
+
+export async function handleChat(
+  port: chrome.runtime.Port,
+  messages: ChatMessage[],
+  context: PRContext,
+  signal: AbortSignal,
+  enrichedContext?: EnrichedPRContext,
+) {
+  const { apiKey, proxyUrl } = await getSettings();
+  if (!apiKey) {
+    sendToPort(port, {
+      type: "error",
+      message:
+        "No API key configured. Click the PRobe extension icon to add your Anthropic API key.",
+    });
+    return;
+  }
+
+  const skills = await resolveSkillsForDiff(context.diff);
+
+  if (skills.length > 0) {
+    sendToPort(port, {
+      type: "skills",
+      skills: skills.map((s) => ({
+        name: s.name,
+        sourceUrl: s.sourceUrl,
+        description: s.description,
+      })),
+    });
+  }
+
+  let systemPrompt: string;
+  if (context.focusedFile) {
+    systemPrompt = buildFileSystemPrompt(
+      context,
+      context.focusedFile,
+      context.diff,
+      context.focusedFileContent,
+      context.focusedLineRange,
+      skills,
+    );
+  } else if (enrichedContext) {
+    systemPrompt = buildEnrichedSystemPrompt(enrichedContext, skills);
+  } else {
+    systemPrompt = buildSystemPrompt(context, skills);
+  }
+
+  sendToPort(port, { type: "system-prompt", content: systemPrompt });
+
+  const anthropicMessages = messages.map((m) => ({
+    role: m.role as "user" | "assistant",
+    content: m.content,
+  }));
+
+  const endpoint = `${proxyUrl.replace(/\/$/, "")}/v1/messages`;
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": ANTHROPIC_API_VERSION,
+      },
+      body: JSON.stringify({
+        model: MODEL_ID,
+        max_tokens: 4096,
+        stream: true,
+        system: systemPrompt,
+        messages: anthropicMessages,
+      }),
+      signal,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      let errorMessage = `Anthropic API error (${response.status})`;
+      try {
+        const parsed = JSON.parse(errorBody);
+        errorMessage = parsed?.error?.message ?? errorMessage;
+      } catch {
+        /* use default */
+      }
+      sendToPort(port, { type: "error", message: errorMessage });
+      return;
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      sendToPort(port, { type: "error", message: "No response body" });
+      return;
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        const data = line.slice(6).trim();
+        if (data === "[DONE]") continue;
+        try {
+          const event = JSON.parse(data);
+          if (event.type === "content_block_delta" && event.delta?.type === "text_delta") {
+            sendToPort(port, { type: "chunk", content: event.delta.text });
+          }
+        } catch {
+          /* skip malformed SSE */
+        }
+      }
+    }
+
+    sendToPort(port, { type: "done" });
+  } catch (err: unknown) {
+    if (signal.aborted) return;
+    sendToPort(port, {
+      type: "error",
+      message: err instanceof Error ? err.message : "Unknown error",
+    });
+  }
+}

--- a/src/background/skillResolver.ts
+++ b/src/background/skillResolver.ts
@@ -1,0 +1,73 @@
+import {
+  detectExtensionsFromDiff,
+  matchSkills,
+  type SkillEntry,
+  type ResolvedSkill,
+} from "../shared/skills";
+
+const SKILL_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 h
+
+interface CachedSkill {
+  content: string;
+  fetchedAt: number;
+}
+
+function stripYamlFrontmatter(md: string): string {
+  return md.replace(/^---[\s\S]*?---\s*/, "");
+}
+
+async function fetchSkillContent(skill: SkillEntry): Promise<string | null> {
+  const cacheKey = `skill:${skill.id}`;
+
+  const cached = await new Promise<CachedSkill | null>((resolve) => {
+    chrome.storage.local.get([cacheKey], (result) => {
+      const data = result[cacheKey] as CachedSkill | undefined;
+      if (data && Date.now() - data.fetchedAt < SKILL_CACHE_TTL) {
+        resolve(data);
+      } else {
+        resolve(null);
+      }
+    });
+  });
+
+  if (cached) return cached.content;
+
+  try {
+    const res = await fetch(skill.rawUrl);
+    if (!res.ok) return null;
+
+    let content = stripYamlFrontmatter(await res.text());
+
+    if (content.length > skill.maxContentLength) {
+      const cutoff = content.lastIndexOf("\n", skill.maxContentLength);
+      content =
+        content.slice(0, cutoff > 0 ? cutoff : skill.maxContentLength) +
+        "\n\n… [truncated for brevity]";
+    }
+
+    chrome.storage.local.set({
+      [cacheKey]: { content, fetchedAt: Date.now() } satisfies CachedSkill,
+    });
+
+    return content;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveSkillsForDiff(diff: string): Promise<ResolvedSkill[]> {
+  const extensions = detectExtensionsFromDiff(diff);
+  const matched = matchSkills(extensions);
+  if (matched.length === 0) return [];
+
+  const results = await Promise.all(
+    matched.map(async (skill) => {
+      const content = await fetchSkillContent(skill);
+      return content
+        ? { name: skill.name, content, sourceUrl: skill.sourceUrl, description: skill.description }
+        : null;
+    }),
+  );
+
+  return results.filter((r): r is ResolvedSkill => r !== null);
+}

--- a/src/content/components/ChatInput.tsx
+++ b/src/content/components/ChatInput.tsx
@@ -128,9 +128,9 @@ export function ChatInput({
           )}
           {hasFocusBullets && focusBullets && (
             <div className="grid grid-cols-2 gap-2">
-              {focusBullets.map((item, i) => (
+              {focusBullets.map((item) => (
                 <button
-                  key={i}
+                  key={item.label}
                   onClick={() => onSend(item.prompt)}
                   className="starter-pill px-3 py-2 rounded-xl text-xs truncate"
                   title={item.prompt}
@@ -157,9 +157,9 @@ export function ChatInput({
 
       {!showStarters && !isStreaming && followUpSuggestions && followUpSuggestions.length > 0 && (
         <div className="flex gap-2 px-3 py-2.5 border-t border-border">
-          {followUpSuggestions.map((item, i) => (
+          {followUpSuggestions.map((item) => (
             <button
-              key={i}
+              key={item.label}
               onClick={() => onSend(item.prompt)}
               className="starter-pill flex-1 px-3 py-2 rounded-xl text-xs truncate"
               title={item.prompt}

--- a/src/content/components/ChatPanel.tsx
+++ b/src/content/components/ChatPanel.tsx
@@ -6,6 +6,7 @@ import { SetupGuide } from "./SetupGuide";
 import { X, ArrowLeft, Zap, ExternalLink, ScanEye } from "lucide-react";
 import { ContextInspector } from "./ContextInspector";
 import { getIconUrl } from "../utils/theme";
+import { parsePromptSuggestions } from "../../shared/parsing";
 import type {
   ChatMessage,
   PRContext,
@@ -61,6 +62,8 @@ export function ChatPanel({
   const storageKeyRef = useRef<string>("");
   const lastAssistantContentRef = useRef<string>("");
   const reviewKeyRef = useRef<string>("");
+  const onDiffLoadedRef = useRef(onDiffLoaded);
+  useEffect(() => { onDiffLoadedRef.current = onDiffLoaded; }, [onDiffLoaded]);
 
   const checkKeys = useCallback(() => {
     chrome.storage.sync.get([STORAGE_KEYS.API_KEY, STORAGE_KEYS.GITHUB_TOKEN], (result) => {
@@ -92,7 +95,7 @@ export function ChatPanel({
         const context = await extractPRContext();
         if (cancelled) return;
         setPrContext(context);
-        onDiffLoaded(context.diff);
+        onDiffLoadedRef.current(context.diff);
 
         const key = STORAGE_KEYS.chatHistory(context.owner, context.repo, context.number);
         storageKeyRef.current = key;
@@ -140,7 +143,6 @@ export function ChatPanel({
         chrome.runtime.sendMessage({ type: "cancel-enriched-context", requestId: enrichedContextRequestId });
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [needsSetup]);
 
   const focusKey = focusedItems
@@ -196,6 +198,12 @@ export function ChatPanel({
     setPendingReview([]);
     persistReview([]);
   }, [persistReview]);
+
+  const handleSummaryLoading = useCallback(() => setFocusBulletsLoading(true), []);
+  const handleSummaryReady = useCallback((bullets: PromptSuggestion[]) => {
+    setFocusBullets(bullets);
+    setFocusBulletsLoading(false);
+  }, []);
 
   const primaryFile = focusedItems.length > 0 ? focusedItems[0].file : null;
 
@@ -325,19 +333,8 @@ export function ChatPanel({
           let cleanContent = fullContent;
           if (match) {
             try {
-              const parsed: unknown = JSON.parse(match[1]);
-              if (Array.isArray(parsed)) {
-                const suggestions = parsed
-                  .filter(
-                    (s): s is PromptSuggestion =>
-                      typeof s === "object" &&
-                      s !== null &&
-                      typeof (s as Record<string, unknown>).label === "string" &&
-                      typeof (s as Record<string, unknown>).prompt === "string",
-                  )
-                  .slice(0, 2);
-                if (suggestions.length > 0) setFollowUpSuggestions(suggestions);
-              }
+              const suggestions = parsePromptSuggestions(JSON.parse(match[1]));
+              if (suggestions.length > 0) setFollowUpSuggestions(suggestions);
             } catch { /* malformed JSON — skip */ }
             cleanContent = fullContent.slice(0, fullContent.length - match[0].length).trimEnd();
           }
@@ -505,11 +502,8 @@ export function ChatPanel({
               fileLine={fileLine.line}
               fileSide={fileLine.side}
               onAddToReview={handleAddToReview}
-              onSummaryLoading={() => setFocusBulletsLoading(true)}
-              onSummaryReady={(bullets) => {
-                setFocusBullets(bullets);
-                setFocusBulletsLoading(false);
-              }}
+              onSummaryLoading={handleSummaryLoading}
+              onSummaryReady={handleSummaryReady}
             />
           )}
 

--- a/src/content/components/PRDashboard.tsx
+++ b/src/content/components/PRDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   PRContext,
   PRStats,
@@ -38,11 +38,23 @@ const REVIEW_STATE_LABELS: Record<string, string> = {
   PENDING: "Pending",
 };
 
+const REVIEW_STATE_COLORS: Record<string, string> = {
+  APPROVED: "text-[#16a34a]",
+  CHANGES_REQUESTED: "text-[#dc2626]",
+};
+
 export function PRDashboard({ prContext, onSummaryLoading, onSummaryReady }: PRDashboardProps) {
   const [stats, setStats] = useState<PRStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [_summary, setSummary] = useState<PromptSuggestion[] | null>(null);
   const [_summaryLoading, setSummaryLoading] = useState(false);
+
+  const onSummaryLoadingRef = useRef(onSummaryLoading);
+  const onSummaryReadyRef = useRef(onSummaryReady);
+  useEffect(() => {
+    onSummaryLoadingRef.current = onSummaryLoading;
+    onSummaryReadyRef.current = onSummaryReady;
+  }, [onSummaryLoading, onSummaryReady]);
 
   useEffect(() => {
     let cancelled = false;
@@ -59,7 +71,7 @@ export function PRDashboard({ prContext, onSummaryLoading, onSummaryReady }: PRD
         if (res?.ok && res.stats) {
           setStats(res.stats);
           setSummaryLoading(true);
-          onSummaryLoading?.();
+          onSummaryLoadingRef.current?.();
           chrome.runtime.sendMessage(
             {
               type: "generate-pr-summary",
@@ -74,7 +86,7 @@ export function PRDashboard({ prContext, onSummaryLoading, onSummaryReady }: PRD
               if (cancelled) return;
               if (sumRes?.ok && sumRes.bullets) {
                 setSummary(sumRes.bullets);
-                onSummaryReady?.(sumRes.bullets);
+                onSummaryReadyRef.current?.(sumRes.bullets);
               }
               setSummaryLoading(false);
             },
@@ -87,8 +99,7 @@ export function PRDashboard({ prContext, onSummaryLoading, onSummaryReady }: PRD
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [prContext.owner, prContext.repo, prContext.number]);
+  }, [prContext.owner, prContext.repo, prContext.number, prContext.title, prContext.description]);
 
   if (loading) {
     return <DashboardSkeleton />;
@@ -190,13 +201,7 @@ export function PRDashboard({ prContext, onSummaryLoading, onSummaryReady }: PRD
                 )}
                 <span className="text-[0.7rem] text-foreground">{r.login}</span>
                 <span
-                  className={`text-[0.6rem] ml-auto ${
-                    r.state === "APPROVED"
-                      ? "text-[#16a34a]"
-                      : r.state === "CHANGES_REQUESTED"
-                        ? "text-[#dc2626]"
-                        : "text-muted-foreground"
-                  }`}
+                  className={`text-[0.6rem] ml-auto ${REVIEW_STATE_COLORS[r.state] ?? "text-muted-foreground"}`}
                 >
                   {REVIEW_STATE_LABELS[r.state] ?? r.state}
                 </span>

--- a/src/content/components/ReviewQueue.tsx
+++ b/src/content/components/ReviewQueue.tsx
@@ -98,7 +98,7 @@ export function ReviewQueue({ pending, owner, repo, number, onClear, onRemove }:
               <div className="max-h-[160px] overflow-y-auto p-2 space-y-1">
                 {pending.map((c, i) => (
                   <div
-                    key={i}
+                    key={`${c.path}:${c.line}:${c.timestamp}`}
                     className="group flex items-start gap-2 p-2 rounded-lg bg-surface border border-border hover:border-mint/40 transition-colors"
                   >
                     <div className="flex-1 min-w-0">

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -227,17 +227,22 @@ function buildLinkedIssuesSection(ctx: EnrichedPRContext): string {
   return `\n\n## Linked Issues\n${blocks.join("\n\n")}`;
 }
 
+const FILE_STATUS_INDICATOR: Record<string, string> = {
+  added: "(new)",
+  removed: "(deleted)",
+  renamed: "(renamed)",
+};
+
+const FILE_STATUS_LABELS: Record<string, string> = {
+  added: "new file",
+  removed: "deleted",
+  renamed: "renamed",
+};
+
 function buildFileTreeSection(ctx: EnrichedPRContext): string {
   if (ctx.files.length === 0) return "";
   const lines = ctx.files.map((f) => {
-    const indicator =
-      f.status === "added"
-        ? "(new)"
-        : f.status === "removed"
-          ? "(deleted)"
-          : f.status === "renamed"
-            ? "(renamed)"
-            : "";
+    const indicator = FILE_STATUS_INDICATOR[f.status] ?? "";
     return `- ${f.filename} ${indicator} +${f.additions}/-${f.deletions}`.trimEnd();
   });
   return `\n\n## Changed Files (${ctx.files.length} files)\n${lines.join("\n")}`;
@@ -288,14 +293,7 @@ function buildPerFileSections(ctx: EnrichedPRContext): string {
     const fullContent = fileContents[f.filename];
     const isDeleted = f.status === "removed";
 
-    const statusLabel =
-      f.status === "added"
-        ? "new file"
-        : f.status === "removed"
-          ? "deleted"
-          : f.status === "renamed"
-            ? "renamed"
-            : "modified";
+    const statusLabel = FILE_STATUS_LABELS[f.status] ?? "modified";
 
     const header = `## File: \`${f.filename}\` (${statusLabel}, +${f.additions}/-${f.deletions})`;
 

--- a/src/shared/parsing.ts
+++ b/src/shared/parsing.ts
@@ -1,0 +1,14 @@
+import type { PromptSuggestion } from "./types";
+
+export function parsePromptSuggestions(raw: unknown): PromptSuggestion[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter(
+      (s): s is PromptSuggestion =>
+        typeof s === "object" &&
+        s !== null &&
+        typeof (s as Record<string, unknown>).label === "string" &&
+        typeof (s as Record<string, unknown>).prompt === "string",
+    )
+    .slice(0, 2);
+}


### PR DESCRIPTION
> **Stacked on** #23 (CWS compliance fixes) — merge that first.

## Summary
- **Split `background/index.ts`** (1025 lines) into 5 focused modules: `helpers.ts`, `githubApi.ts`, `llmService.ts`, `skillResolver.ts`, and a slim 130-line `index.ts` dispatcher with a handler registry (Open/Closed principle — adding a new message type is now a one-line change)
- **Eliminated code duplication**: extracted `dispatchAsync()` (replaces 7 copy-pasted `.catch` blocks), `parsePromptSuggestions()` (was duplicated in background + ChatPanel), and `NO_TOKEN_ERROR` (was repeated 3x)
- **Fixed React correctness issues**: replaced suppressed `exhaustive-deps` warnings with proper ref patterns, wrapped inline JSX callbacks in `useCallback`, replaced array-index keys with stable keys
- **Replaced nested ternaries** with lookup maps (`FILE_STATUS_LABELS`, `FILE_STATUS_INDICATOR`, `REVIEW_STATE_COLORS`)
- **Named magic values**: `GITHUB_API_VERSION`, `ANTHROPIC_API_VERSION`, `MAX_COMMIT_DETAILS`, `FILE_CONTENT_BUDGET`, `PER_FILE_CONTENT_CAP`

### Files changed
| File | Change |
|------|--------|
| `src/background/index.ts` | 1025 → 130 lines (slim dispatcher) |
| `src/background/githubApi.ts` | New — all GitHub REST calls |
| `src/background/llmService.ts` | New — Anthropic streaming + summary |
| `src/background/skillResolver.ts` | New — skill matching and caching |
| `src/background/helpers.ts` | New — `dispatchAsync()`, `sendToPort()` |
| `src/shared/parsing.ts` | New — shared `parsePromptSuggestions()` |
| `src/shared/constants.ts` | Replaced nested ternaries with lookups |
| `src/content/components/ChatPanel.tsx` | `useCallback`, ref pattern, shared parsing |
| `src/content/components/PRDashboard.tsx` | Ref pattern for callback props, lookup map |
| `src/content/components/ReviewQueue.tsx` | Stable keys |
| `src/content/components/ChatInput.tsx` | Stable keys |

Part of #21

## Test plan
- [ ] `npm run build` succeeds — verify `dist/` output is unchanged in behavior
- [ ] All 23 tests pass (`npm test`)
- [ ] ESLint shows no new errors (2 pre-existing `set-state-in-effect` errors remain in `App.tsx` and `ChatPanel.tsx`)
- [ ] Load unpacked extension → open a GitHub PR → verify chat, file focus, line focus, review queue, and PR dashboard all work end-to-end
- [ ] Verify streaming responses still work correctly (the port handler logic moved to `llmService.ts`)